### PR TITLE
Create terraform files to provision a GCS bucket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,11 +10,12 @@ crash.log
 crash.*.log
 
 # Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
 # to change depending on the environment.
 *.tfvars
 *.tfvars.json
+*.json
 
 # Ignore override files as they are usually used to override resources locally and so
 # are not checked in

--- a/gcp/.terraform.lock.hcl
+++ b/gcp/.terraform.lock.hcl
@@ -1,0 +1,40 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version = "5.34.0"
+  hashes = [
+    "h1:t48NNfGkdHByEWWiKx6GtlZPlzEB1Dha3cq44Uidev0=",
+    "zh:143c88bb74631041c291ebf7b6213467bf376d3775a33815785939dc102fac09",
+    "zh:1616ac79345f472b33fcc388eaf4a8a3002e4cc3a5e8748d60d6f4786d0d16dc",
+    "zh:554ce78e73349ac2c893a74b6981f5e55169ca16f4d0f239e6ccdecadbe1c9e1",
+    "zh:8022f97aa907685b2eb6c39d5411cf2be2448c6f3b7fbeaf9c06618d376ac4bc",
+    "zh:85f1fe3628954c35379cc05b895091ec8fe8ba0a5610bc9660492d5be65d4902",
+    "zh:873fb64fca79695aa930cd868b41ac498809eb76bc3292e41460d916c6fa3538",
+    "zh:8d3c5112a4abf14b42d769f78373e66f2c2f5f03a7e6544d80019a695bd9b198",
+    "zh:93cbcfa38991965b976d1973bc528d666006b5247c3fda00c714d0f3a2b62d3e",
+    "zh:b7710246637aee522a4ea4c1b4f0effb83b701546124ae90c8b4afb97ce03aba",
+    "zh:e4e02fe946ccbe192b6bbc6bed5715cf68084f1faadc134ed99d5e732429d2ca",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fb6b1e4fb2d019d2740aa21b5ecd5f0609f562633a78604a96c14c94aff762b4",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/google-beta" {
+  version = "5.34.0"
+  hashes = [
+    "h1:HIgDlZlb6fzgCHh/NZQW9byVzN11Mt6T0Ay0TDW87Sg=",
+    "zh:01619cfe684471dc88d470cf157f7adc659a2f6849346d6be2a71efe1cbd0250",
+    "zh:1b6b2401862aaaf08819cf83b27a147957f0bcc1821a3b94a438788760cb65ad",
+    "zh:30d3fbaa204dd1d197d01ed5385a5d325fd8d313a5fdcf7cdd80209f1740247f",
+    "zh:461d084c0a0590785134218d57df39f34863a8977e4e925585eea085c86c97b5",
+    "zh:534bc4652861bdcbe0451673269d326477781d70a9f03cae3b780d574f29f841",
+    "zh:6e8abcd37a9609b05aab3529ccc3414b6d1258b124e58754b62f28fd4f3877a7",
+    "zh:838a31873ce35e40e52ba0513aec5ff519159e99459829f0ea590eb62714801a",
+    "zh:9387550c9e45e68c7ac5d6839a8f88e8e525ebf81a4c76847f7c05f13bf5dc19",
+    "zh:997ac33e5d72f0aecfddd5235ba4dbe82b5bbaf811b801849e419942e204a12b",
+    "zh:a66fbccde0dd854f764bf247576eaea4898966b6814db232fa45e789dc2ca014",
+    "zh:d60efed82a54ff41a8f2380f83fefd9477616f49296e349b5a41fccb558fde08",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+  ]
+}

--- a/gcp/custom-roles.tf
+++ b/gcp/custom-roles.tf
@@ -1,0 +1,15 @@
+resource "google_project_iam_custom_role" "gcs_bucket_admin" {
+  role_id     = "gcs_bucket_admin"
+  title       = "GCS Bucket Admin"
+  description = "GCS Bucket Admin role for service accounts only"
+  permissions = [
+    "orgpolicy.policy.get",
+    "resourcemanager.projects.get",
+    "resourcemanager.projects.list",
+    "storage.managedFolders.create",
+    "storage.managedFolders.delete",
+    "storage.managedFolders.get",
+    "storage.managedFolders.list",
+    "storage.multipartUploads.*",
+  "storage.objects.*"]
+}

--- a/gcp/gcs.tf
+++ b/gcp/gcs.tf
@@ -1,0 +1,6 @@
+# Create GCS bucket resources
+
+resource "google_storage_bucket" "test_bucket" {
+  name     = "test-bucket"
+  location = "US"
+}

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -1,0 +1,19 @@
+# Provider
+
+provider "google" {
+  project     = var.gcp_project_id
+  region      = var.gcp_region
+  credentials = file(var.gcp_svc_key)
+  default_labels = {
+    owner = "shazni"
+  }
+}
+
+provider "google-beta" {
+  project     = var.gcp_project_id
+  region      = var.gcp_region
+  credentials = file(var.gcp_svc_key)
+  default_labels = {
+    owner = "shazni"
+  }
+}

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -1,0 +1,3 @@
+variable "gcp_svc_key" {}
+variable "gcp_project_id" {}
+variable "gcp_region" {}


### PR DESCRIPTION
We added the terraform files to specify Google as the provider and provision a GCS bucket resource. The variables are stored in a `terraform.tfvars` that is ignored when committed. Since the key is in json, we have also ignored that in the commit. Ideally, the key is to be stored in a secrets manager or using Google's Workload Identity Federation.